### PR TITLE
Update runtime to 5.15-21.08

### DIFF
--- a/org.cubocore.CoreShot.yml
+++ b/org.cubocore.CoreShot.yml
@@ -1,6 +1,6 @@
 app-id: org.cubocore.CoreShot
 runtime: org.kde.Platform
-runtime-version: '5.15'
+runtime-version: '5.15-21.08'
 sdk: org.kde.Sdk
 command: coreshot
 finish-args:


### PR DESCRIPTION
The 5.15 version of the KDE Runtime is based on the 20.08 version of the Freedesktop Runtime and will stay as-is to keep compatibility.
The 5.15-21.08 version of the KDE Runtime is based on the 21.08 Freedesktop one. The Qt/KDE Libraries are mostyl similar between the two runtimes.

This change is mostly maintenance to keep the base runtime updated.